### PR TITLE
style: :art: Alteração do widget 'Column' para 'Row'

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,7 +89,7 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Center(
         // Center is a layout widget. It takes a single child and positions it
         // in the middle of the parent.
-        child: Column(
+        child: Row(
           // Column is also a layout widget. It takes a list of children and
           // arranges them vertically. By default, it sizes itself to fit its
           // children horizontally, and tries to be as tall as its parent.


### PR DESCRIPTION
Foi alterado do widget de 'Column' para 'Row' para que o filhos (children) sejam exibidos em linhas ao inves de coluna.

![codigo alteração](https://github.com/queirozmat/contador_dartmode/assets/82989763/714a7353-d3cd-479c-9359-c63514890da9)
